### PR TITLE
Switch to brace initialization assignment

### DIFF
--- a/src/bounded_reg.cpp
+++ b/src/bounded_reg.cpp
@@ -103,7 +103,7 @@ SEXP bounded_reg(SEXP X        ,
   // Initializing "first level" variables (outside of the lambda1 loop)
   colvec beta     = zeros<vec>(p)          ; // vector of current parameters
   uvec   B          (p)                    ; // guys reaching the boundary
-  for (int i=0;i<p;i++){B(i) = i;}
+  for (size_t i=0;i<p;i++){B(i) = i;}
   mat    coef                              ; // matrice of solution path
   vec    grd                               ; // smooth part of the gradient
   vec    mu        = zeros<vec>(n_lambda)  ; // the intercept term
@@ -125,7 +125,7 @@ SEXP bounded_reg(SEXP X        ,
   //
   // START THE LOOP OVER LAMBDA
   timer.tic();
-  for (int m=0; m<n_lambda; m++) {
+  for (size_t m=0; m<n_lambda; m++) {
     if (verbose == 2) {Rprintf("\n lambda1 = %f",lambda1(m)) ;}
 
     // _____________________________________________________________

--- a/src/elastic_net.cpp
+++ b/src/elastic_net.cpp
@@ -142,7 +142,7 @@ SEXP elastic_net(SEXP BETA0    ,
       xtxA = mat(xt * x.cols(A)) ;
     }
     if (lambda2 > 0) {
-      for (int i=0; i<A.n_elem;i++) {
+      for (uword i=0; i<A.n_elem;i++) {
 	xtxA.col(i) = xtxA.col(i) + S.col(A(i));
 	are_in(A(i)) = 1;
       }
@@ -168,7 +168,7 @@ SEXP elastic_net(SEXP BETA0    ,
   //
   // START THE LOOP OVER LAMBDA
   timer.tic();
-  for (int m=0; m<n_lambda; m++) {
+  for (uword m=0; m<n_lambda; m++) {
     if (verbose == 2) {Rprintf("\n lambda1 = %f",lambda1(m)) ;}
     // _____________________________________________________________
     //
@@ -241,7 +241,7 @@ SEXP elastic_net(SEXP BETA0    ,
       // removing variables zeroed during optimization
       if (!null.is_empty()) {
 	if (verbose == 2) {
-	  for (int j=0; j<null.n_elem; j++) {Rprintf("removing variable %i\n",null[j]);}
+	  for (uword j=0; j<null.n_elem; j++) {Rprintf("removing variable %i\n",null[j]);}
 	}
 	remove_var_enet(nbr_in,are_in,betaA,A,xtxA,xAtxA,xtxw,R,null,usechol,fun) ;
       }
@@ -287,7 +287,7 @@ SEXP elastic_net(SEXP BETA0    ,
     if (it_active[m] >= max_iter) {
       converge[m] = 1;
     }
-    if (nbr_in > max_feat) {
+    if (static_cast<uword>(nbr_in) > max_feat) {
       converge[m] = 2 ;
     }
     if (!success_optim) {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -111,7 +111,7 @@ void add_var_enet(uword &n, int &nbr_in, uword &var_in, vec &betaA, uvec &A, sp_
 
 void remove_var_enet(int &nbr_in, uvec &are_in, vec &betaA, uvec &A, mat &xtxA, mat &xAtxA, mat &xtxw, mat &R, uvec &null, bool &usechol, uword &fun) {
 
-  for (int j=0; j<null.n_elem; j++) {
+  for (uword j=0; j<null.n_elem; j++) {
     are_in[A(null[j])]  = 0 ;
     A.shed_row(null[j])     ;
     betaA.shed_row(null[j]) ;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -29,8 +29,8 @@ void choldowndate(mat &R, int j) {
 
     if (x[1] != 0) {
       r = norm(x,2);
-      G <<  x(0) << x(1) << endr
-	<< -x(1) << x(0) << endr;
+      G = { {  x(0), x(1) },
+            { -x(1), x(0) }  };
       G = G / r;
       x(0) = r; x(1) = 0;
     } else {

--- a/src/utils.h
+++ b/src/utils.h
@@ -66,7 +66,7 @@ void standardize(any_mat &x, vec &y, bool &intercept, bool &normalize, vec &pens
 
   if (normalize == 1) {
     normx = sqrt(trans(sum(square(x),0)) - n * square(xbar));
-    for (int i=0; i<p; i++) {
+    for (uword i=0; i<p; i++) {
       x.col(i) /= normx(i);
     }
     xbar /= normx ;
@@ -76,7 +76,7 @@ void standardize(any_mat &x, vec &y, bool &intercept, bool &normalize, vec &pens
   normy = sqrt(sum(square(y))) ;
 
   if (any(penscale != 1)) {
-    for (int i=0; i<n; i++) {
+    for (uword i=0; i<n; i++) {
        x.row(i) /= penscale ;
     }
     xbar /= penscale;
@@ -84,7 +84,7 @@ void standardize(any_mat &x, vec &y, bool &intercept, bool &normalize, vec &pens
 
   if (intercept == 1) {
     xty = trans(trans(y-ybar) * x) ;
-    for (int i=0;i<p;i++) {
+    for (uword i=0;i<p;i++) {
        xty(i) -=  sum(y-ybar) * xbar(i);
     }
   } else {


### PR DESCRIPTION
The following change allows `quadrupen` to compile without triggering the deprecatation warning.