### PR TITLE
Update DESCRIPTION with URL and BugReports fields

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,8 @@ Suggests:
 LinkingTo: Rcpp, RcppArmadillo
 NeedsCompilation: yes
 Maintainer: Julien Chiquet <julien.chiquet@inrae.fr>
+URL: https://github.com/jchiquet/quadrupenCRAN
+BugReports: https://github.com/jchiquet/quadrupenCRAN/issues
 Encoding: UTF-8
 RoxygenNote: 7.2.3
 Language: en-US


### PR DESCRIPTION
These two fields are not mandatory but permitted, somewhat common -- and useful as they make it easier to find the repo.  I missed it yesterday and could not send a pull request (my bad).   Maybe something for the next CRAN update?